### PR TITLE
feat(chat): allowing preferences between trigger or user settings

### DIFF
--- a/core/src/main/java/net/flectone/pulse/config/Message.java
+++ b/core/src/main/java/net/flectone/pulse/config/Message.java
@@ -208,8 +208,6 @@ public final class Message extends FileSerializable implements ModuleConfig.Mess
     public static final class Chat implements SubMessageConfig, Config.IEnable {
         private boolean enable = true;
         private Mode mode = Mode.BUKKIT;
-        // Settings is the default because this was the old functionality
-        private Prefer prefer = Prefer.SETTINGS;
         private Event.Priority priority = Event.Priority.NORMAL;
         private Map<String, Type> types = new LinkedHashMap<>(){
             {
@@ -222,11 +220,6 @@ public final class Message extends FileSerializable implements ModuleConfig.Mess
             BUKKIT,
             PAPER,
             PACKET
-        }
-
-        public enum Prefer {
-            TRIGGER,
-            SETTINGS
         }
 
         @Getter

--- a/core/src/main/java/net/flectone/pulse/config/Message.java
+++ b/core/src/main/java/net/flectone/pulse/config/Message.java
@@ -208,6 +208,8 @@ public final class Message extends FileSerializable implements ModuleConfig.Mess
     public static final class Chat implements SubMessageConfig, Config.IEnable {
         private boolean enable = true;
         private Mode mode = Mode.BUKKIT;
+        // Settings is the default because this was the old functionality
+        private Prefer prefer = Prefer.SETTINGS;
         private Event.Priority priority = Event.Priority.NORMAL;
         private Map<String, Type> types = new LinkedHashMap<>(){
             {
@@ -220,6 +222,11 @@ public final class Message extends FileSerializable implements ModuleConfig.Mess
             BUKKIT,
             PAPER,
             PACKET
+        }
+
+        public enum Prefer {
+            TRIGGER,
+            SETTINGS
         }
 
         @Getter

--- a/core/src/main/java/net/flectone/pulse/module/message/chat/ChatModule.java
+++ b/core/src/main/java/net/flectone/pulse/module/message/chat/ChatModule.java
@@ -113,7 +113,7 @@ public class ChatModule extends AbstractModuleLocalization<Localization.Message.
             return;
         }
 
-        Message.Chat.Type playerChat = message.getTypes().getOrDefault(fPlayer.getSettingValue(FPlayer.Setting.CHAT), getPlayerChat(fPlayer, eventMessage));
+        Message.Chat.Type playerChat = getPreferenceBasedChat(fPlayer, eventMessage);
 
         var configChatEntry = message.getTypes().entrySet()
                 .stream()
@@ -249,6 +249,25 @@ public class ChatModule extends AbstractModuleLocalization<Localization.Message.
                 .message(string)
                 .sound(getSound())
                 .sendBuilt();
+    }
+
+    private Message.Chat.Type getPreferenceBasedChat(FPlayer fPlayer, String message) {
+        Message.Chat.Prefer prefer = this.message.getPrefer();
+
+        if (prefer.equals(Message.Chat.Prefer.TRIGGER)) {
+            // If that chat *does* have a trigger, override all behavior.
+            if (this.message.getTypes().get(fPlayer.getSettingValue(FPlayer.Setting.CHAT)) != null) {
+                Message.Chat.Type playerChat = this.message.getTypes().get(fPlayer.getSettingValue(FPlayer.Setting.CHAT));
+
+                if (playerChat.getTrigger() != null
+                        && !playerChat.getTrigger().isEmpty()) {
+                    return playerChat;
+                }
+            }
+
+            return getPlayerChat(fPlayer, message);
+        }
+        return this.message.getTypes().getOrDefault(fPlayer.getSettingValue(FPlayer.Setting.CHAT), getPlayerChat(fPlayer, message));
     }
 
     private Message.Chat.Type getPlayerChat(FPlayer fPlayer, String message) {

--- a/core/src/main/java/net/flectone/pulse/module/message/chat/ChatModule.java
+++ b/core/src/main/java/net/flectone/pulse/module/message/chat/ChatModule.java
@@ -26,6 +26,7 @@ import net.flectone.pulse.platform.registry.ListenerRegistry;
 import net.flectone.pulse.processing.resolver.FileResolver;
 import net.flectone.pulse.service.FPlayerService;
 import net.flectone.pulse.util.constant.MessageType;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -113,7 +114,7 @@ public class ChatModule extends AbstractModuleLocalization<Localization.Message.
             return;
         }
 
-        Message.Chat.Type playerChat = getPreferenceBasedChat(fPlayer, eventMessage);
+        Message.Chat.Type playerChat = getPlayerChat(fPlayer, eventMessage);
 
         var configChatEntry = message.getTypes().entrySet()
                 .stream()
@@ -251,40 +252,25 @@ public class ChatModule extends AbstractModuleLocalization<Localization.Message.
                 .sendBuilt();
     }
 
-    private Message.Chat.Type getPreferenceBasedChat(FPlayer fPlayer, String message) {
-        Message.Chat.Prefer prefer = this.message.getPrefer();
+    private Message.Chat.Type getPlayerChat(FPlayer fPlayer, String eventMessage) {
+        Message.Chat.Type playerChat = message.getTypes().get(fPlayer.getSettingValue(FPlayer.Setting.CHAT));
 
-        if (prefer.equals(Message.Chat.Prefer.TRIGGER)) {
-            // If that chat *does* have a trigger, override all behavior.
-            if (this.message.getTypes().get(fPlayer.getSettingValue(FPlayer.Setting.CHAT)) != null) {
-                Message.Chat.Type playerChat = this.message.getTypes().get(fPlayer.getSettingValue(FPlayer.Setting.CHAT));
-
-                if (playerChat.getTrigger() != null
-                        && !playerChat.getTrigger().isEmpty()) {
-                    return playerChat;
-                }
-            }
-
-            return getPlayerChat(fPlayer, message);
+        // if that chat *does* have a trigger, return it
+        if (playerChat != null && !StringUtils.isEmpty(playerChat.getTrigger())) {
+            return playerChat;
         }
-        return this.message.getTypes().getOrDefault(fPlayer.getSettingValue(FPlayer.Setting.CHAT), getPlayerChat(fPlayer, message));
-    }
-
-    private Message.Chat.Type getPlayerChat(FPlayer fPlayer, String message) {
-        Message.Chat.Type playerChat = null;
 
         int priority = Integer.MIN_VALUE;
 
         for (var entry : this.message.getTypes().entrySet()) {
-
             Message.Chat.Type chat = entry.getValue();
             String chatName = entry.getKey();
 
             if (!chat.isEnable()) continue;
             if (chat.getTrigger() != null
                     && !chat.getTrigger().isEmpty()
-                    && !message.startsWith(chat.getTrigger())) continue;
-            if (message.equals(chat.getTrigger())) continue;
+                    && !eventMessage.startsWith(chat.getTrigger())) continue;
+            if (eventMessage.equals(chat.getTrigger())) continue;
 
             if (chat.getPriority() <= priority) continue;
             if (!permissionChecker.check(fPlayer, permission.getTypes().get(chatName))) continue;


### PR DESCRIPTION
Hello there! I've recently ran into the limitation of how this plugin's message "type" selection method works. FlectonePulse seems to always prioritize user settings over triggers in messages. This may have been intentional, so, I decided to add a new configuration value in the `chat` module:

```yml
chat:
  enable: true
  mode: PAPER
  prefer: TRIGGER
  priority: "HIGHEST"
```

`prefer` can be either `TRIGGER` or `SETTINGS`
  - `SETTINGS` is the old behavior, and the default value. It prioritizes user setting selection over the triggers in the message.
  - `TRIGGER` prioritizes the trigger in the message, and uses that for the current message type. However, users that have a message type in their settings that does have a trigger, it will prioritize their user settings instead.

For example, with `TRIGGER` used as a value:
 - Users with `global` (has no trigger) in their settings that send any message will be directed to `staff-chat` if they have permissions and their message starts with `staff-chat`'s trigger
 - Users with `staff-chat` (has a trigger) in their settings that send any message will get directed to `staff-chat` regardless of message contents (like vanilla behavior)

This seems like the right way in my personal opinion on how to select channels, however server admins always have a choice on which way they would like this plugin to resolve message type selection.