### PR TITLE
Fixed InteractiveChat raw tags in discord ( Maybe )

### DIFF
--- a/core/src/main/java/net/flectone/pulse/platform/formatter/IntegrationFormatter.java
+++ b/core/src/main/java/net/flectone/pulse/platform/formatter/IntegrationFormatter.java
@@ -117,8 +117,8 @@ public class IntegrationFormatter {
                 .message(text)
                 .flags(eventMetadata.flags())
                 .flags(
-                        new MessageFlag[]{MessageFlag.TRANSLATE_MODULE, MessageFlag.OBJECT_SPRITE_PROCESSING, MessageFlag.OBJECT_PLAYER_HEAD_PROCESSING},
-                        new boolean[]{false, false, false}
+                        new MessageFlag[]{MessageFlag.TRANSLATE_MODULE, MessageFlag.OBJECT_SPRITE_PROCESSING, MessageFlag.OBJECT_PLAYER_HEAD_PROCESSING, MessageFlag.INTERACTIVE_CHAT_COMPAT},
+                        new boolean[]{false, false, false, false}
                 );
 
         TagResolver[] tagResolvers = eventMetadata.resolveTags(FPlayer.UNKNOWN);


### PR DESCRIPTION
Возможное исправление сырого сообщения с тегами от InteractiveChat ( Замечал только в дискорде, но так же должен фиксить тг и твич )
<img width="557" height="26" alt="изображение" src="https://github.com/user-attachments/assets/06917203-012d-4109-ace3-3452ddcd4239" />
