### PR TITLE
Тоже shit-ошибка

### DIFF
--- a/core/src/main/java/net/flectone/pulse/platform/formatter/IntegrationFormatter.java
+++ b/core/src/main/java/net/flectone/pulse/platform/formatter/IntegrationFormatter.java
@@ -117,8 +117,8 @@ public class IntegrationFormatter {
                 .message(text)
                 .flags(eventMetadata.flags())
                 .flags(
-                        new MessageFlag[]{MessageFlag.TRANSLATE_MODULE, MessageFlag.OBJECT_SPRITE_PROCESSING, MessageFlag.OBJECT_PLAYER_HEAD_PROCESSING},
-                        new boolean[]{false, false, false}
+                        new MessageFlag[]{MessageFlag.TRANSLATE_MODULE, MessageFlag.OBJECT_SPRITE_PROCESSING, MessageFlag.OBJECT_PLAYER_HEAD_PROCESSING, MessageFlag.INTERACTIVE_CHAT_COMPAT},
+                        new boolean[]{false, false, false, false}
                 );
 
         TagResolver[] tagResolvers = eventMetadata.resolveTags(FPlayer.UNKNOWN);

--- a/minecraft/common/src/main/java/net/flectone/pulse/module/message/bubble/render/MinecraftBubbleRender.java
+++ b/minecraft/common/src/main/java/net/flectone/pulse/module/message/bubble/render/MinecraftBubbleRender.java
@@ -213,17 +213,14 @@ public class MinecraftBubbleRender implements BubbleRender {
                 .receiver(viewer)
                 .message(bubble.getRawMessage())
                 .flags(
-                        new MessageFlag[]{MessageFlag.MENTION_MODULE, MessageFlag.INTERACTIVE_CHAT_COMPAT, MessageFlag.QUESTIONANSWER_MODULE, MessageFlag.PLAYER_MESSAGE, MessageFlag.OBJECT_DEFAULT_VALUE},
-                        new boolean[]{false, false, false, true, true}
+                        new MessageFlag[]{MessageFlag.MENTION_MODULE, MessageFlag.INTERACTIVE_CHAT_COMPAT, MessageFlag.QUESTIONANSWER_MODULE, MessageFlag.PLAYER_MESSAGE},
+                        new boolean[]{false, false, false, true}
                 )
                 .build();
 
         return messagePipeline.build(messageContext.toBuilder()
                 .message(localization.format())
-                .flags(
-                        new MessageFlag[]{MessageFlag.PLAYER_MESSAGE, MessageFlag.OBJECT_DEFAULT_VALUE},
-                        new boolean[]{false, true}
-                )
+                .flag(MessageFlag.PLAYER_MESSAGE, false)
                 .tagResolver(messagePipeline.resolver("message", (_, _) -> Tag.inserting(messagePipeline.build(messageContext))))
                 .build()
         );

--- a/minecraft/common/src/main/java/net/flectone/pulse/module/message/bubble/render/MinecraftBubbleRender.java
+++ b/minecraft/common/src/main/java/net/flectone/pulse/module/message/bubble/render/MinecraftBubbleRender.java
@@ -213,14 +213,17 @@ public class MinecraftBubbleRender implements BubbleRender {
                 .receiver(viewer)
                 .message(bubble.getRawMessage())
                 .flags(
-                        new MessageFlag[]{MessageFlag.MENTION_MODULE, MessageFlag.INTERACTIVE_CHAT_COMPAT, MessageFlag.QUESTIONANSWER_MODULE, MessageFlag.PLAYER_MESSAGE},
-                        new boolean[]{false, false, false, true}
+                        new MessageFlag[]{MessageFlag.MENTION_MODULE, MessageFlag.INTERACTIVE_CHAT_COMPAT, MessageFlag.QUESTIONANSWER_MODULE, MessageFlag.PLAYER_MESSAGE, MessageFlag.OBJECT_DEFAULT_VALUE},
+                        new boolean[]{false, false, false, true, true}
                 )
                 .build();
 
         return messagePipeline.build(messageContext.toBuilder()
                 .message(localization.format())
-                .flag(MessageFlag.PLAYER_MESSAGE, false)
+                .flags(
+                        new MessageFlag[]{MessageFlag.PLAYER_MESSAGE, MessageFlag.OBJECT_DEFAULT_VALUE},
+                        new boolean[]{false, true}
+                )
                 .tagResolver(messagePipeline.resolver("message", (_, _) -> Tag.inserting(messagePipeline.build(messageContext))))
                 .build()
         );

--- a/minecraft/common/src/main/java/net/flectone/pulse/module/message/format/object/MinecraftObjectModule.java
+++ b/minecraft/common/src/main/java/net/flectone/pulse/module/message/format/object/MinecraftObjectModule.java
@@ -36,6 +36,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 
 @Singleton
 public class MinecraftObjectModule extends ObjectModule {
@@ -155,9 +156,13 @@ public class MinecraftObjectModule extends ObjectModule {
 
         playerHeadBuilder.hat(!argumentQueue.hasNext() || Boolean.parseBoolean(argumentQueue.pop().value()));
 
-        if (playerHead.length() > 16) {
+        if (isValidName(playerHead)) {
             playerHeadBuilder.profileProperty(PlayerHeadObjectContents.property("textures", playerHead));
         } else {
+            if (playerHead.length() < 16) {
+                return MessagePipeline.ReplacementTag.emptyTag();
+            }
+
             UUID playerHeadUUID = uuidParser.parse(playerHead);
             if (playerHeadUUID != null) {
                 FPlayer fPlayer = fPlayerService.getFPlayer(playerHeadUUID);
@@ -173,6 +178,12 @@ public class MinecraftObjectModule extends ObjectModule {
         Component playerHeadComponent = Component.object().contents(playerHeadBuilder.build()).build();
 
         return applyDefaultFormatting(messageContext, playerHeadComponent, config().playerHeadTag().needExtraSpace());
+    }
+
+    // https://github.com/PaperMC/adventure/blob/main/5/api/src/main/java/net/kyori/adventure/text/object/PlayerHeadObjectContentsImpl.java
+    private boolean isValidName(final String name) {
+        if (name.length() > 16) return false;
+        return name.chars().filter(c -> c <= 32 || c >= 126).findAny().isEmpty();
     }
 
     private void applyFPlayerProfileProperty(FEntity fEntity,

--- a/minecraft/common/src/main/java/net/flectone/pulse/module/message/format/object/MinecraftObjectModule.java
+++ b/minecraft/common/src/main/java/net/flectone/pulse/module/message/format/object/MinecraftObjectModule.java
@@ -156,22 +156,25 @@ public class MinecraftObjectModule extends ObjectModule {
 
         playerHeadBuilder.hat(!argumentQueue.hasNext() || Boolean.parseBoolean(argumentQueue.pop().value()));
 
+        // first check valid player name
         if (isValidName(playerHead)) {
-            playerHeadBuilder.profileProperty(PlayerHeadObjectContents.property("textures", playerHead));
-        } else {
-            if (playerHead.length() < 16) {
-                return MessagePipeline.ReplacementTag.emptyTag();
-            }
+            // try load this player
+            FPlayer fPlayer = fPlayerService.getFPlayer(playerHead);
 
+            // apply custom property
+            applyFPlayerProfileProperty(fPlayer, playerHeadBuilder, builder -> builder.name(playerHead));
+        } else {
+            // second check player uuid
             UUID playerHeadUUID = uuidParser.parse(playerHead);
             if (playerHeadUUID != null) {
+                // try load this player
                 FPlayer fPlayer = fPlayerService.getFPlayer(playerHeadUUID);
 
+                // apply custom property
                 applyFPlayerProfileProperty(fPlayer, playerHeadBuilder, builder -> builder.id(playerHeadUUID));
             } else {
-                FPlayer fPlayer = fPlayerService.getFPlayer(playerHead);
-
-                applyFPlayerProfileProperty(fPlayer, playerHeadBuilder, builder -> builder.name(playerHead));
+                // or insert value to textures
+                playerHeadBuilder.profileProperty(PlayerHeadObjectContents.property("textures", playerHead));
             }
         }
 


### PR DESCRIPTION
Исправление кика игроков рядом от `<player_head:ник>` в чат баблах xD

Теперь в бабле включен `OBJECT_DEFAULT_VALUE`, чтобы в баблах "лица" отправлялись безопасным символом-фаллбеком, а то не кайф устраивать кик-резню
<img width="751" height="263" alt="Discord_3iY372kqlk" src="https://github.com/user-attachments/assets/3b161b34-45b2-4744-b306-de4dc3e347c7" />