### PR TITLE
fix(fabric): bundle adventure into the fabric jar so the mod runs standalone

### DIFF
--- a/minecraft-fabric/build.gradle
+++ b/minecraft-fabric/build.gradle
@@ -20,6 +20,19 @@ dependencies {
 	compileOnlyApi "com.github.retrooper:packetevents-fabric-official:$packetevents_spigot_version"
 	compileOnlyApi "org.incendo:cloud-fabric:${cloud_fabric_version}"
 
+	// Bundle adventure so the mod is standalone on Fabric. The root build.gradle
+	// declares adventure as compileOnlyApi, which shadow's `include(dependency("net.kyori:.*"))`
+	// cannot resolve against the runtime classpath - published fabric jars ended up
+	// with zero net/kyori classes while core bytecode still references the unrelocated
+	// package, causing IncompatibleClassChangeError/NoSuchMethodError at runtime when
+	// another mod (e.g. SkinsRestorer) ships a different adventure version.
+	implementation "net.kyori:adventure-api:${adventure_api}"
+	implementation "net.kyori:adventure-text-minimessage:${adventure_api}"
+	implementation "net.kyori:adventure-text-serializer-ansi:${adventure_api}"
+	implementation "net.kyori:adventure-text-serializer-plain:${adventure_api}"
+	implementation "net.kyori:adventure-text-serializer-legacy:${adventure_api}"
+	implementation "net.kyori:adventure-text-serializer-gson:${adventure_api}"
+
 	// integrations
 	compileOnly "eu.pb4:placeholder-api:$text_placeholder_api_version"
 	compileOnly "maven.modrinth:vanish:$vanish_version"
@@ -38,6 +51,7 @@ shadowJar {
 		include(dependency("com.alessiodp.libby:.*"))
 		include(dependency("org.xerial:.*"))
 		include(dependency("net.kyori:.*"))
+		include(dependency("com.google.code.gson:.*"))
 		include(dependency("org.incendo:.*"))
 		include(dependency("net.flectone:.*"))
 		include(project(":core"))


### PR DESCRIPTION
Fixes #437

## Problem
Published flectonepulse-fabric jars ship **zero** `net/kyori` classes, while core bytecode still references the **unrelocated** `net.kyori.adventure.*` package. The root build.gradle declares adventure as `compileOnlyApi`, so shadow's `include(dependency("net.kyori:.*"))` - which resolves against the runtime classpath - never picks it up, and the `relocate("net.kyori.adventure", ...)` rule never runs.

At runtime on a Fabric server the mod then grabs whatever adventure another mod happens to ship. With SkinsRestorer (legacy 4.19-4.25 layout) plus packetevents 2.13.0 (ships adventure **4.26.1** via jar-in-jar, a breaking release: `ClickEvent.Action` became final again / `TextCarrier` removed / `Services` refactored) the server dies with:
```
IncompatibleClassChangeError: class net.kyori.adventure.text.event.ClickEvent$Action$TextCarrier cannot inherit from final class net.kyori.adventure.text.event.ClickEvent$Action
```

## Fix
In `minecraft-fabric/build.gradle`, declare the adventure artifacts used by core as `implementation` so shadow can include them; they get relocated into `net.flectone.pulse.library.adventure` inside the jar (the existing include + relocate rules now actually fire). Also include `com.google.code.gson` since core uses gson directly (e.g. `com.google.gson.Gson` in proxy cache listeners) and `adventure-text-serializer-gson` needs it.

The mod becomes fully standalone: no more reliance on whatever adventure another mod ships, immune to version clashes with SkinsRestorer / packetevents / MiniMOTD etc.

## Verification
Built `:minecraft-fabric:buildFinalJar` (JDK 25) and inspected `flectonepulse-fabric.jarinjar`:
- 543 classes under `net/flectone/pulse/library/adventure/` (relocated adventure 4.26.1, incl. minimessage)
- 210 classes under `net/flectone/pulse/library/gson/`
- zero raw `net/kyori/adventure/*` classes (only `net.kyori.option` / `examination` / `ansi` helpers, which are bundled and self-consistent)
- `javap` on `PlatformInjector.class` confirms bytecode now references `net/flectone/pulse/library/adventure/text/minimessage/MiniMessage`

Note: the NeoForge build (`implementation.extendsFrom shadow`) likely has the same underlying issue and may need the same treatment in a follow-up.